### PR TITLE
feat: add methods returning errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,8 @@ func ExampleSelfSigned() {
 
 	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		_, err := w.Write([]byte("TLS works!\n"))
-		if err != nil {
-			log.Printf("Failed to write response: %v", err)
-		}
+		//nolint:errcheck
+		w.Write([]byte("TLS works!\n"))
 	})
 
 	go func() {
@@ -183,10 +181,8 @@ func ExampleSelfSignedE() {
 
 	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		_, err := w.Write([]byte("TLS works!\n"))
-		if err != nil {
-			log.Printf("Failed to write response: %v", err)
-		}
+		//nolint:errcheck
+		w.Write([]byte("TLS works!\n"))
 	})
 
 	go func() {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ func ExampleSelfSigned() {
 	defer os.RemoveAll(certsDir)
 
 	if err := os.MkdirAll(certsDir, 0o755); err != nil {
-		log.Fatal(err) // nolint: gocritic
+		log.Println(err)
+		return
 	}
 
 	// Generate a certificate for localhost and save it to disk.
@@ -68,7 +69,8 @@ func ExampleSelfSigned() {
 		ParentDir: certsDir,
 	})
 	if caCert == nil {
-		log.Fatal("Failed to generate CA certificate")
+		log.Println("Failed to generate CA certificate")
+		return
 	}
 
 	cert := tlscert.SelfSignedFromRequest(tlscert.Request{
@@ -78,7 +80,8 @@ func ExampleSelfSigned() {
 		ParentDir: certsDir,
 	})
 	if cert == nil {
-		log.Fatal("Failed to generate certificate")
+		log.Println("Failed to generate certificate")
+		return
 	}
 
 	// create an http server that uses the generated certificate
@@ -97,7 +100,9 @@ func ExampleSelfSigned() {
 	})
 
 	go func() {
-		_ = server.ListenAndServeTLS(cert.CertPath, cert.KeyPath)
+		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil {
+			log.Printf("Failed to start server: %v", err)
+		}
 	}()
 	defer server.Close()
 
@@ -108,13 +113,15 @@ func ExampleSelfSigned() {
 	client := &http.Client{Transport: cert.Transport()}
 	resp, err := client.Get(url)
 	if err != nil {
-		log.Fatalf("Failed to get response: %v", err)
+		log.Printf("Failed to get response: %v", err)
+		return
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("Failed to read response body: %v", err)
+		log.Printf("Failed to read response body: %v", err)
+		return
 	}
 
 	fmt.Println(string(body))
@@ -133,7 +140,8 @@ func ExampleSelfSignedE() {
 	defer os.RemoveAll(certsDir)
 
 	if err := os.MkdirAll(certsDir, 0o755); err != nil {
-		log.Fatal(err) // nolint: gocritic
+		log.Println(err)
+		return
 	}
 
 	// Generate a certificate for localhost and save it to disk.
@@ -143,10 +151,12 @@ func ExampleSelfSignedE() {
 		ParentDir: certsDir,
 	})
 	if err != nil {
-		log.Fatal("Failed to generate CA certificate")
+		log.Println("Failed to generate CA certificate")
+		return
 	}
 	if caCert == nil {
-		log.Fatal("Failed to generate CA certificate")
+		log.Println("Failed to generate CA certificate")
+		return
 	}
 
 	cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
@@ -156,10 +166,12 @@ func ExampleSelfSignedE() {
 		ParentDir: certsDir,
 	})
 	if err != nil {
-		log.Fatal("Failed to generate certificate")
+		log.Println("Failed to generate certificate")
+		return
 	}
 	if cert == nil {
-		log.Fatal("Failed to generate certificate")
+		log.Println("Failed to generate certificate")
+		return
 	}
 
 	// create an http server that uses the generated certificate
@@ -178,7 +190,9 @@ func ExampleSelfSignedE() {
 	})
 
 	go func() {
-		_ = server.ListenAndServeTLS(cert.CertPath, cert.KeyPath)
+		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil {
+			log.Printf("Failed to start server: %v", err)
+		}
 	}()
 	defer server.Close()
 
@@ -189,13 +203,15 @@ func ExampleSelfSignedE() {
 	client := &http.Client{Transport: cert.Transport()}
 	resp, err := client.Get(url)
 	if err != nil {
-		log.Fatalf("Failed to get response: %v", err)
+		log.Printf("Failed to get response: %v", err)
+		return
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("Failed to read response body: %v", err)
+		log.Printf("Failed to read response body: %v", err)
+		return
 	}
 
 	fmt.Println(string(body))

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,6 @@
+package tlscert
+
+import "errors"
+
+// ErrHostRequired is returned when the host is required but not provided.
+var ErrHostRequired = errors.New("host is required")

--- a/examples_test.go
+++ b/examples_test.go
@@ -80,3 +80,80 @@ func ExampleSelfSigned() {
 	// Output:
 	// TLS works!
 }
+
+func ExampleSelfSignedE() {
+	tmp := os.TempDir()
+	certsDir := tmp + "/certs"
+	defer os.RemoveAll(certsDir)
+
+	if err := os.MkdirAll(certsDir, 0o755); err != nil {
+		log.Fatal(err) // nolint: gocritic
+	}
+
+	// Generate a certificate for localhost and save it to disk.
+	caCert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+		Host:      "localhost",
+		Name:      "ca-cert",
+		ParentDir: certsDir,
+	})
+	if err != nil {
+		log.Fatal("Failed to generate CA certificate")
+	}
+	if caCert == nil {
+		log.Fatal("Failed to generate CA certificate")
+	}
+
+	cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+		Host:      "localhost",
+		Name:      "client-cert",
+		Parent:    caCert,
+		ParentDir: certsDir,
+	})
+	if err != nil {
+		log.Fatal("Failed to generate certificate")
+	}
+	if cert == nil {
+		log.Fatal("Failed to generate certificate")
+	}
+
+	// create an http server that uses the generated certificate
+	// and private key to serve requests over HTTPS
+
+	server := &http.Server{
+		Addr: ":8443",
+	}
+
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, err := w.Write([]byte("TLS works!\n"))
+		if err != nil {
+			log.Printf("Failed to write response: %v", err)
+		}
+	})
+
+	go func() {
+		_ = server.ListenAndServeTLS(cert.CertPath, cert.KeyPath)
+	}()
+	defer server.Close()
+
+	// perform an HTTP request to the server, using the generated certificate
+
+	const url = "https://localhost:8443/hello"
+
+	client := &http.Client{Transport: cert.Transport()}
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Fatalf("Failed to get response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Failed to read response body: %v", err)
+	}
+
+	fmt.Println(string(body))
+
+	// Output:
+	// TLS works!
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,6 +1,7 @@
 package tlscert_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -55,7 +56,7 @@ func ExampleSelfSigned() {
 	})
 
 	go func() {
-		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil {
+		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("Failed to start server: %v", err)
 		}
 	}()
@@ -138,7 +139,7 @@ func ExampleSelfSignedE() {
 	})
 
 	go func() {
-		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil {
+		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("Failed to start server: %v", err)
 		}
 	}()

--- a/examples_test.go
+++ b/examples_test.go
@@ -51,10 +51,8 @@ func ExampleSelfSigned() {
 
 	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		_, err := w.Write([]byte("TLS works!\n"))
-		if err != nil {
-			log.Printf("Failed to write response: %v", err)
-		}
+		//nolint:errcheck
+		w.Write([]byte("TLS works!\n"))
 	})
 
 	go func() {
@@ -137,10 +135,8 @@ func ExampleSelfSignedE() {
 
 	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		_, err := w.Write([]byte("TLS works!\n"))
-		if err != nil {
-			log.Printf("Failed to write response: %v", err)
-		}
+		//nolint:errcheck
+		w.Write([]byte("TLS works!\n"))
 	})
 
 	go func() {

--- a/examples_test.go
+++ b/examples_test.go
@@ -51,8 +51,7 @@ func ExampleSelfSigned() {
 
 	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		//nolint:errcheck
-		w.Write([]byte("TLS works!\n"))
+		w.Write([]byte("TLS works!\n")) //nolint:errcheck
 	})
 
 	go func() {
@@ -135,8 +134,7 @@ func ExampleSelfSignedE() {
 
 	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
-		//nolint:errcheck
-		w.Write([]byte("TLS works!\n"))
+		w.Write([]byte("TLS works!\n")) //nolint:errcheck
 	})
 
 	go func() {

--- a/examples_test.go
+++ b/examples_test.go
@@ -16,7 +16,8 @@ func ExampleSelfSigned() {
 	defer os.RemoveAll(certsDir)
 
 	if err := os.MkdirAll(certsDir, 0o755); err != nil {
-		log.Fatal(err) // nolint: gocritic
+		log.Println(err)
+		return
 	}
 
 	// Generate a certificate for localhost and save it to disk.
@@ -26,7 +27,8 @@ func ExampleSelfSigned() {
 		ParentDir: certsDir,
 	})
 	if caCert == nil {
-		log.Fatal("Failed to generate CA certificate")
+		log.Println("Failed to generate CA certificate")
+		return
 	}
 
 	cert := tlscert.SelfSignedFromRequest(tlscert.Request{
@@ -36,7 +38,8 @@ func ExampleSelfSigned() {
 		ParentDir: certsDir,
 	})
 	if cert == nil {
-		log.Fatal("Failed to generate certificate")
+		log.Println("Failed to generate certificate")
+		return
 	}
 
 	// create an http server that uses the generated certificate
@@ -55,7 +58,9 @@ func ExampleSelfSigned() {
 	})
 
 	go func() {
-		_ = server.ListenAndServeTLS(cert.CertPath, cert.KeyPath)
+		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil {
+			log.Printf("Failed to start server: %v", err)
+		}
 	}()
 	defer server.Close()
 
@@ -66,13 +71,15 @@ func ExampleSelfSigned() {
 	client := &http.Client{Transport: cert.Transport()}
 	resp, err := client.Get(url)
 	if err != nil {
-		log.Fatalf("Failed to get response: %v", err)
+		log.Printf("Failed to get response: %v", err)
+		return
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("Failed to read response body: %v", err)
+		log.Printf("Failed to read response body: %v", err)
+		return
 	}
 
 	fmt.Println(string(body))
@@ -87,7 +94,8 @@ func ExampleSelfSignedE() {
 	defer os.RemoveAll(certsDir)
 
 	if err := os.MkdirAll(certsDir, 0o755); err != nil {
-		log.Fatal(err) // nolint: gocritic
+		log.Println(err)
+		return
 	}
 
 	// Generate a certificate for localhost and save it to disk.
@@ -97,10 +105,12 @@ func ExampleSelfSignedE() {
 		ParentDir: certsDir,
 	})
 	if err != nil {
-		log.Fatal("Failed to generate CA certificate")
+		log.Println("Failed to generate CA certificate")
+		return
 	}
 	if caCert == nil {
-		log.Fatal("Failed to generate CA certificate")
+		log.Println("Failed to generate CA certificate")
+		return
 	}
 
 	cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
@@ -110,10 +120,12 @@ func ExampleSelfSignedE() {
 		ParentDir: certsDir,
 	})
 	if err != nil {
-		log.Fatal("Failed to generate certificate")
+		log.Println("Failed to generate certificate")
+		return
 	}
 	if cert == nil {
-		log.Fatal("Failed to generate certificate")
+		log.Println("Failed to generate certificate")
+		return
 	}
 
 	// create an http server that uses the generated certificate
@@ -132,7 +144,9 @@ func ExampleSelfSignedE() {
 	})
 
 	go func() {
-		_ = server.ListenAndServeTLS(cert.CertPath, cert.KeyPath)
+		if err := server.ListenAndServeTLS(cert.CertPath, cert.KeyPath); err != nil {
+			log.Printf("Failed to start server: %v", err)
+		}
 	}()
 	defer server.Close()
 
@@ -143,13 +157,15 @@ func ExampleSelfSignedE() {
 	client := &http.Client{Transport: cert.Transport()}
 	resp, err := client.Get(url)
 	if err != nil {
-		log.Fatalf("Failed to get response: %v", err)
+		log.Printf("Failed to get response: %v", err)
+		return
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("Failed to read response body: %v", err)
+		log.Printf("Failed to read response body: %v", err)
+		return
 	}
 
 	fmt.Println(string(body))

--- a/tlscert.go
+++ b/tlscert.go
@@ -292,7 +292,7 @@ func SelfSignedFromRequestE(req Request) (*Certificate, error) {
 	return certificate, nil
 }
 
-// santiiseName returns a sanitised version of the name, replacing spaces with underscores.
+// sanitiseName returns a sanitised version of the name, replacing spaces with underscores.
 func sanitiseName(name string) string {
 	if name == "" {
 		name = time.Now().Format("2006-01-02T15:04:05")

--- a/tlscert.go
+++ b/tlscert.go
@@ -276,14 +276,14 @@ func SelfSignedFromRequestE(req Request) (*Certificate, error) {
 		certPath := filepath.Join(req.ParentDir, "cert-"+id+".pem")
 
 		if err := os.WriteFile(certPath, certificate.Bytes, 0o644); err != nil {
-			return certificate, fmt.Errorf("write certificate to file: %w", err)
+			return nil, fmt.Errorf("write certificate to file: %w", err)
 		}
 		certificate.CertPath = certPath
 
 		if certificate.KeyBytes != nil {
 			keyPath := filepath.Join(req.ParentDir, "key-"+id+".pem")
 			if err := os.WriteFile(keyPath, certificate.KeyBytes, 0o644); err != nil {
-				return certificate, fmt.Errorf("write key to file: %w", err)
+				return nil, fmt.Errorf("write key to file: %w", err)
 			}
 			certificate.KeyPath = keyPath
 		}

--- a/tlscert_test.go
+++ b/tlscert_test.go
@@ -522,7 +522,7 @@ func TestTLSConfig(t *testing.T) {
 	t.Run("cached/error", func(t *testing.T) {
 		cert, err := tlscert.SelfSignedE("")
 		if err == nil {
-			t.Fatal("expected error to be nil, got", err)
+			t.Fatal("expected error, got nil")
 		}
 		if cert != nil {
 			t.Fatal("expected cert to be nil, got", cert)

--- a/tlscert_test.go
+++ b/tlscert_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mdelapenya/tlscert"
@@ -477,6 +478,21 @@ func TestSelfSignedE(t *testing.T) {
 			if string(cert) != string(fileCert.Certificate[i]) {
 				tt.Fatalf("expected certificate to be %s, got %s\n", string(cert), string(fileCert.Certificate[i]))
 			}
+		}
+	})
+
+	t.Run("save-to-file/error", func(tt *testing.T) {
+		tmp := filepath.Join(tt.TempDir(), "non-existing-dir")
+
+		cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+			Host:      "localhost",
+			ParentDir: tmp,
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if cert != nil {
+			t.Fatal("expected cert to be nil, got", cert)
 		}
 	})
 }

--- a/tlscert_test.go
+++ b/tlscert_test.go
@@ -2,6 +2,7 @@ package tlscert_test
 
 import (
 	"crypto/tls"
+	"errors"
 	"net"
 	"os"
 	"testing"
@@ -228,8 +229,260 @@ func TestSelfSigned(t *testing.T) {
 	})
 }
 
+func TestSelfSignedE(t *testing.T) {
+	t.Run("No host returns error", func(t *testing.T) {
+		cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{Host: ""})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, tlscert.ErrHostRequired) {
+			t.Fatalf("expected error to be %s, got %s\n", tlscert.ErrHostRequired, err)
+		}
+		if cert != nil {
+			t.Fatal("expected cert to be nil, got", cert)
+		}
+	})
+
+	t.Run("With host", func(tt *testing.T) {
+		cert, err := tlscert.SelfSignedE("localhost")
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		if cert.Key == nil {
+			tt.Fatal("expected key, got nil")
+		}
+
+		if cert.Bytes == nil {
+			t.Fatal("expected bytes, got nil")
+		}
+		if cert.KeyBytes == nil {
+			t.Fatal("expected key bytes, got nil")
+		}
+
+		_, err = tls.X509KeyPair(cert.Bytes, cert.KeyBytes)
+		if err != nil {
+			tt.Fatal(err)
+		}
+	})
+
+	t.Run("With multiple hosts", func(t *testing.T) {
+		ip := "1.2.3.4"
+		cert, err := tlscert.SelfSignedE("localhost, " + ip)
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		if cert.Key == nil {
+			t.Fatal("expected key, got nil")
+		}
+
+		c := cert.Cert
+		if len(c.IPAddresses) != 1 {
+			t.Fatal("expected 1 IP address, got", len(c.IPAddresses))
+		}
+
+		if c.IPAddresses[0].String() != ip {
+			t.Fatalf("expected IP address to be %s, got %s\n", ip, c.IPAddresses[0].String())
+		}
+	})
+
+	t.Run("With multiple hosts and IPs", func(t *testing.T) {
+		ip := "1.2.3.4"
+		ips := []net.IP{net.ParseIP("4.5.6.7"), net.ParseIP("8.9.10.11")}
+		cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+			Host:        "localhost, " + ip,
+			IPAddresses: ips,
+		})
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		if cert.Key == nil {
+			t.Fatal("expected key, got nil")
+		}
+
+		c := cert.Cert
+		if len(c.IPAddresses) != 3 {
+			t.Fatal("expected 3 IP address, got", len(c.IPAddresses))
+		}
+
+		for i, ip := range ips {
+			if c.IPAddresses[i].String() != ip.String() {
+				t.Fatalf("expected IP address to be %s, got %s\n", ip.String(), c.IPAddresses[i].String())
+			}
+		}
+		// the IP from the host comes after the IPs from the IPAddresses option
+		if c.IPAddresses[2].String() != ip {
+			t.Fatalf("expected IP address to be %s, got %s\n", ip, c.IPAddresses[0].String())
+		}
+	})
+
+	t.Run("As CA", func(t *testing.T) {
+		cert, err := tlscert.SelfSignedCAE("localhost")
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		if cert.Cert == nil {
+			t.Fatal("expected cert, got nil")
+		}
+		if cert.Key == nil {
+			t.Fatal("expected key, got nil")
+		}
+		if cert.Bytes == nil {
+			t.Fatal("expected bytes, got nil")
+		}
+
+		if !cert.Cert.IsCA {
+			t.Fatal("expected cert to be CA, got false")
+		}
+	})
+
+	t.Run("With Subject common name", func(t *testing.T) {
+		cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+			Host:              "localhost",
+			SubjectCommonName: "Test",
+		})
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		if cert.Cert == nil {
+			t.Fatal("expected cert, got nil")
+		}
+
+		c := cert.Cert
+		if c.Subject.CommonName != "Test" {
+			t.Fatal("expected common name to be Test, got", c.Subject.CommonName)
+		}
+	})
+
+	t.Run("With Parent cert", func(t *testing.T) {
+		parent, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+			Host:              "localhost",
+			SubjectCommonName: "Acme Inc.",
+			IsCA:              true,
+		})
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if parent == nil {
+			t.Fatal("expected parent to be not nil, got", parent)
+		}
+
+		cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+			Host:   "localhost",
+			Parent: parent,
+		})
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		if cert.Cert == nil {
+			t.Fatal("expected cert, got nil")
+		}
+		if cert.Key == nil {
+			t.Fatal("expected key, got nil")
+		}
+
+		c := cert.Cert
+		if c.Issuer.CommonName != parent.Cert.Subject.CommonName {
+			t.Fatal("expected issuer to be parent, got", c.Issuer.CommonName)
+		}
+	})
+
+	t.Run("With IP addresses", func(t *testing.T) {
+		ip := "1.2.3.4"
+
+		cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+			Host:        "localhost",
+			IPAddresses: []net.IP{net.ParseIP(ip)},
+		})
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		if cert.Cert == nil {
+			t.Fatal("expected cert, got nil")
+		}
+
+		c := cert.Cert
+		if len(c.IPAddresses) != 1 {
+			t.Fatal("expected 1 IP address, got", len(c.IPAddresses))
+		}
+
+		if c.IPAddresses[0].String() != ip {
+			t.Fatalf("expected IP address to be %s, got %s\n", ip, c.IPAddresses[0].String())
+		}
+	})
+
+	t.Run("Save to file", func(tt *testing.T) {
+		tmp := tt.TempDir()
+
+		cert, err := tlscert.SelfSignedFromRequestE(tlscert.Request{
+			Host:      "localhost",
+			ParentDir: tmp,
+		})
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		inMemoryCert, err := tls.X509KeyPair(cert.Bytes, cert.KeyBytes)
+		if err != nil {
+			tt.Fatal(err)
+		}
+
+		// check if file existed
+		certBytes, err := os.ReadFile(cert.CertPath)
+		if err != nil {
+			tt.Fatal(err)
+		}
+
+		certKeyBytes, err := os.ReadFile(cert.KeyPath)
+		if err != nil {
+			tt.Fatal(err)
+		}
+
+		fileCert, err := tls.X509KeyPair(certBytes, certKeyBytes)
+		if err != nil {
+			tt.Fatal(err)
+		}
+
+		for i, cert := range inMemoryCert.Certificate {
+			if string(cert) != string(fileCert.Certificate[i]) {
+				tt.Fatalf("expected certificate to be %s, got %s\n", string(cert), string(fileCert.Certificate[i]))
+			}
+		}
+	})
+}
+
 func TestTLSConfig(t *testing.T) {
-	t.Run("Cached", func(t *testing.T) {
+	t.Run("cached/no-error", func(t *testing.T) {
 		cert := tlscert.SelfSigned("localhost")
 		if cert == nil {
 			t.Fatal("expected cert to be not nil, got", cert)
@@ -247,6 +500,50 @@ func TestTLSConfig(t *testing.T) {
 
 		if config != config2 {
 			t.Fatal("expected config to be the same, got different")
+		}
+	})
+
+	t.Run("cached/error", func(t *testing.T) {
+		cert, err := tlscert.SelfSignedE("")
+		if err == nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert != nil {
+			t.Fatal("expected cert to be nil, got", cert)
+		}
+	})
+
+	t.Run("error/cached/no-error", func(t *testing.T) {
+		cert, err := tlscert.SelfSignedE("localhost")
+		if err != nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert == nil {
+			t.Fatal("expected cert to be not nil, got", cert)
+		}
+
+		config := cert.TLSConfig()
+		if config == nil {
+			t.Fatal("expected config to be not nil, got", config)
+		}
+
+		// force the bytes to be null, but the config should not change
+		cert.Bytes = nil
+
+		config2 := cert.TLSConfig()
+
+		if config != config2 {
+			t.Fatal("expected config to be the same, got different")
+		}
+	})
+
+	t.Run("error/cached/error", func(t *testing.T) {
+		cert, err := tlscert.SelfSignedE("")
+		if err == nil {
+			t.Fatal("expected error to be nil, got", err)
+		}
+		if cert != nil {
+			t.Fatal("expected cert to be nil, got", cert)
 		}
 	})
 }

--- a/tlscert_test.go
+++ b/tlscert_test.go
@@ -90,7 +90,7 @@ func TestSelfSigned(t *testing.T) {
 		}
 		// the IP from the host comes after the IPs from the IPAddresses option
 		if c.IPAddresses[2].String() != ip {
-			t.Fatalf("expected IP address to be %s, got %s\n", ip, c.IPAddresses[0].String())
+			t.Fatalf("expected IP address to be %s, got %s\n", ip, c.IPAddresses[2].String())
 		}
 	})
 
@@ -324,7 +324,7 @@ func TestSelfSignedE(t *testing.T) {
 		}
 		// the IP from the host comes after the IPs from the IPAddresses option
 		if c.IPAddresses[2].String() != ip {
-			t.Fatalf("expected IP address to be %s, got %s\n", ip, c.IPAddresses[0].String())
+			t.Fatalf("expected IP address to be %s, got %s\n", ip, c.IPAddresses[2].String())
 		}
 	})
 

--- a/tlscert_test.go
+++ b/tlscert_test.go
@@ -556,7 +556,7 @@ func TestTLSConfig(t *testing.T) {
 	t.Run("error/cached/error", func(t *testing.T) {
 		cert, err := tlscert.SelfSignedE("")
 		if err == nil {
-			t.Fatal("expected error to be nil, got", err)
+			t.Fatal("expected error, got nil", err)
 		}
 		if cert != nil {
 			t.Fatal("expected cert to be nil, got", cert)


### PR DESCRIPTION
## What is this PR doing?
It adds thre new exposed functions that allow client code to handle the errors produced by the library.

I used the `E` suffix (i.e. `SelfSignedE`) to distinguish from the existing `SelfSigned` avoiding breaking changes.

## Why is it important?
Make client code aware of the underlying errors instead of simply receiving a nil certificate, for reasons :shrug:
